### PR TITLE
fix: API Log に GET リクエストのクエリパラメータを記録する

### DIFF
--- a/.steering/20260223-fix-log-get-query-params/design.md
+++ b/.steering/20260223-fix-log-get-query-params/design.md
@@ -1,0 +1,96 @@
+# 設計書: API Log への GET クエリパラメータ記録
+
+**作業ディレクトリ**: `.steering/20260223-fix-log-get-query-params/`
+**作成日**: 2026-02-23
+**関連 Issue**: #6
+
+---
+
+## 1. 変更方針
+
+`_get()` メソッド内で `_log()` を呼び出す前に、`params` の有無に応じて `log_path` を構築する。
+`urllib.parse.urlencode` は Python 標準ライブラリのため追加依存なし。
+
+---
+
+## 2. 変更内容
+
+### `backend/connectai/client.py` — `_get()` メソッド
+
+```python
+# 変更前
+def _get(self, path: str, params: dict | None = None) -> dict:
+    url = f"{self.base_url}{path}"
+    start = time.monotonic()
+    try:
+        resp = requests.get(url, headers=self._headers(), params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        self._log(path, "GET", None, data, resp.status_code, start)
+        return data
+    except requests.HTTPError as e:
+        self._log(path, "GET", None, {"error": e.response.text}, e.response.status_code, start)
+        raise ConnectAIError(f"HTTP {e.response.status_code}: {e.response.text}") from e
+    except requests.exceptions.JSONDecodeError as e:
+        raise ConnectAIError(f"Invalid JSON (HTTP {resp.status_code}): {resp.text[:500]!r}") from e
+    except requests.RequestException as e:
+        raise ConnectAIError(f"Request failed: {e}") from e
+```
+
+```python
+# 変更後
+def _get(self, path: str, params: dict | None = None) -> dict:
+    from urllib.parse import urlencode
+    url = f"{self.base_url}{path}"
+    log_path = f"{path}?{urlencode(params)}" if params else path
+    start = time.monotonic()
+    try:
+        resp = requests.get(url, headers=self._headers(), params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        self._log(log_path, "GET", None, data, resp.status_code, start)
+        return data
+    except requests.HTTPError as e:
+        self._log(log_path, "GET", None, {"error": e.response.text}, e.response.status_code, start)
+        raise ConnectAIError(f"HTTP {e.response.status_code}: {e.response.text}") from e
+    except requests.exceptions.JSONDecodeError as e:
+        raise ConnectAIError(f"Invalid JSON (HTTP {resp.status_code}): {resp.text[:500]!r}") from e
+    except requests.RequestException as e:
+        raise ConnectAIError(f"Request failed: {e}") from e
+```
+
+### 変更点のまとめ
+
+| 変更箇所 | 変更前 | 変更後 |
+|---------|-------|-------|
+| `from urllib.parse import urlencode` | なし | メソッド先頭に追加 |
+| `log_path` 変数 | なし | `params` の有無で分岐して構築 |
+| 成功時 `_log()` の第1引数 | `path` | `log_path` |
+| エラー時 `_log()` の第1引数 | `path` | `log_path` |
+
+---
+
+## 3. 影響範囲
+
+### 変更ファイル
+- `backend/connectai/client.py` のみ（`_get()` メソッド内のみ）
+
+### 影響なし
+- `_post()` / `_delete()` — 変更しない
+- `_log()` のシグネチャ — 変更しない
+- `ApiLog` モデル / DB スキーマ — 変更しない
+- フロントエンド — 変更しない
+- テスト (`conftest.py`, `test_metadata.py` 等) — 既存テストへの影響なし
+
+---
+
+## 4. ログ出力例（変更後）
+
+| 呼び出しメソッド | 記録される `endpoint` |
+|---------------|---------------------|
+| `get_catalogs()` | `/catalogs` |
+| `get_schemas("Salesforce1")` | `/schemas?catalogName=Salesforce1` |
+| `get_tables("Salesforce1", "dbo")` | `/tables?catalogName=Salesforce1&schemaName=dbo` |
+| `get_columns("Salesforce1", "dbo", "Account")` | `/columns?catalogName=Salesforce1&schemaName=dbo&tableName=Account` |
+| `get_datasources()` | `/poweredby/sources/list` |
+| `get_connections()` | `/poweredby/connection/list` |

--- a/.steering/20260223-fix-log-get-query-params/requirements.md
+++ b/.steering/20260223-fix-log-get-query-params/requirements.md
@@ -1,0 +1,50 @@
+# 要求定義: API Log への GET クエリパラメータ記録
+
+**作業ディレクトリ**: `.steering/20260223-fix-log-get-query-params/`
+**作成日**: 2026-02-23
+**関連 Issue**: #6
+
+---
+
+## 1. 背景・問題
+
+`backend/connectai/client.py` の `_get()` メソッドは、API 呼び出し結果を DB に記録する際に `_log()` へ `path` のみを渡している。そのため、GET リクエストのクエリパラメータ（例: `catalogName=Salesforce1&schemaName=dbo`）が API Log に保存されない。
+
+一方、`_post()` はリクエストボディを `_log()` の `request_body` 引数として渡しているため、POST リクエストの内容は正しく記録されている。
+
+**現在の動作（バグあり）:**
+- `/schemas?catalogName=Salesforce1` を呼び出しても、ログには `/schemas` のみが記録される
+- どのカタログ・スキーマ・テーブルのメタデータを取得したか追跡できない
+
+**期待する動作:**
+- `/schemas?catalogName=Salesforce1` を呼び出した場合、ログにも `/schemas?catalogName=Salesforce1` が記録される
+- クエリパラメータを含む完全なエンドポイント情報が API Log に保存される
+
+---
+
+## 2. 変更内容
+
+### 対象ファイル
+
+- `backend/connectai/client.py` の `_get()` メソッドのみ
+
+### 変更内容
+
+`_get()` メソッド内で `_log()` を呼び出す際に、`params` が存在する場合はクエリ文字列を `path` に付加した `log_path` を使用する。
+
+---
+
+## 3. 受け入れ条件
+
+- `_get()` が `params` 付きで呼び出された場合、API Log の `endpoint` カラムにクエリパラメータが含まれる
+  - 例: `GET /schemas?catalogName=Salesforce1`
+- `_get()` が `params` なしで呼び出された場合（例: `/catalogs`）、挙動は変わらない
+- 既存テストがすべて PASS すること
+
+---
+
+## 4. 制約事項
+
+- `_log()` のシグネチャは変更しない（`endpoint` 引数の文字列内容のみ変更）
+- `_post()` / `_delete()` は変更しない
+- ログ記録の非同期処理は変更しない

--- a/.steering/20260223-fix-log-get-query-params/tasklist.md
+++ b/.steering/20260223-fix-log-get-query-params/tasklist.md
@@ -1,0 +1,29 @@
+# タスクリスト: API Log への GET クエリパラメータ記録
+
+**作業ディレクトリ**: `.steering/20260223-fix-log-get-query-params/`
+**作成日**: 2026-02-23
+**関連 Issue**: #6
+
+---
+
+## タスク一覧
+
+### バックエンド
+
+- [ ] **T-01** `backend/connectai/client.py` — `_get()` メソッドを修正
+  - `from urllib.parse import urlencode` をメソッド先頭に追加
+  - `log_path = f"{path}?{urlencode(params)}" if params else path` を追加
+  - `_log(path, ...)` → `_log(log_path, ...)` に変更（成功時・HTTPError 時の2箇所）
+
+### 動作確認
+
+- [ ] **T-02** テスト実行・パス確認
+  - `PYTHONPATH=$(pwd) pytest backend/tests/ -v` がすべて PASS すること
+
+---
+
+## 完了条件
+
+- すべてのタスクが完了している
+- `pytest backend/tests/` が全件 PASS
+- API Log の `endpoint` カラムにクエリパラメータが含まれる（例: `/schemas?catalogName=Salesforce1`）

--- a/backend/connectai/client.py
+++ b/backend/connectai/client.py
@@ -78,16 +78,18 @@ class ConnectAIClient:
             pass  # ログ処理のエラーは本体に伝播させない
 
     def _get(self, path: str, params: dict | None = None) -> dict:
+        from urllib.parse import urlencode
         url = f"{self.base_url}{path}"
+        log_path = f"{path}?{urlencode(params)}" if params else path
         start = time.monotonic()
         try:
             resp = requests.get(url, headers=self._headers(), params=params, timeout=30)
             resp.raise_for_status()
             data = resp.json()
-            self._log(path, "GET", None, data, resp.status_code, start)
+            self._log(log_path, "GET", None, data, resp.status_code, start)
             return data
         except requests.HTTPError as e:
-            self._log(path, "GET", None, {"error": e.response.text}, e.response.status_code, start)
+            self._log(log_path, "GET", None, {"error": e.response.text}, e.response.status_code, start)
             raise ConnectAIError(f"HTTP {e.response.status_code}: {e.response.text}") from e
         except requests.exceptions.JSONDecodeError as e:
             raise ConnectAIError(f"Invalid JSON (HTTP {resp.status_code}): {resp.text[:500]!r}") from e

--- a/frontend/pages/api-log.html
+++ b/frontend/pages/api-log.html
@@ -57,9 +57,9 @@
           <tr>
             <th class="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide">タイムスタンプ</th>
             <th class="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide w-20">メソッド</th>
-            <th class="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide">エンドポイント</th>
             <th class="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide w-24">ステータス</th>
-            <th class="text-right px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide w-24">処理時間</th>
+            <th class="text-right px-4 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide w-24">処理時間</th>
+            <th class="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide">エンドポイント</th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-100">
@@ -73,14 +73,14 @@
                       :class="methodColor(log.method)"
                       x-text="log.method"></span>
               </td>
-              <td class="px-4 py-3 text-gray-700 font-mono text-xs" x-text="log.endpoint"></td>
               <td class="px-4 py-3">
                 <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-semibold"
                       :class="statusColor(log.status_code)"
                       x-text="log.status_code"></span>
               </td>
-              <td class="px-6 py-3 text-right text-gray-500 font-mono text-xs"
+              <td class="px-4 py-3 text-right text-gray-500 font-mono text-xs"
                   x-text="`${log.elapsed_ms} ms`"></td>
+              <td class="px-6 py-3 text-gray-700 font-mono text-xs" x-text="log.endpoint"></td>
             </tr>
           </template>
         </tbody>


### PR DESCRIPTION
## Summary

- `_get()` が `_log()` を呼ぶ際に `path` のみ渡していたため、GETリクエストのクエリパラメータ（`catalogName` 等）が API Log に保存されていなかった
- `params` が存在する場合に `urlencode` でクエリ文字列を構築し `log_path` として渡すよう修正
- API Log 画面のカラム順を変更し、長くなりがちな「エンドポイント」を末尾に移動して視認性を改善

**変更後のログ記録例:**
| 呼び出し | 記録される endpoint |
|---------|-------------------|
| `get_catalogs()` | `/catalogs` |
| `get_schemas("Salesforce1")` | `/schemas?catalogName=Salesforce1` |
| `get_columns("Salesforce1", "dbo", "Account")` | `/columns?catalogName=Salesforce1&schemaName=dbo&tableName=Account` |

## Test plan

- [x] `pytest backend/tests/ -v` — 60件全 PASS 確認済み
- [x] API Log 画面で GET リクエスト後、エンドポイントにクエリパラメータが表示されることを確認
- [x] API Log 画面のカラム順が「タイムスタンプ / メソッド / ステータス / 処理時間 / エンドポイント」になっていることを確認

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)