### PR TITLE
feat: DevContainer 環境のセットアップと RSA 秘密鍵の環境変数対応

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "ConnectAIOEMSample",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11",
+  "forwardPorts": [5001],
+  "postCreateCommand": "bash .devcontainer/setup.sh",
+  "remoteEnv": {
+    "PYTHONPATH": "${containerWorkspaceFolder}"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.pylance",
+        "ms-python.debugpy"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["backend/tests"],
+        "python.testing.cwd": "${workspaceFolder}"
+      }
+    }
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+echo "=== ConnectAIOEMSample DevContainer セットアップ ==="
+
+# 依存パッケージのインストール
+echo "📦 pip install -r backend/requirements.txt ..."
+pip install -r backend/requirements.txt
+
+# .env が未作成の場合はテンプレートからコピー
+if [ ! -f backend/.env ]; then
+  cp backend/.env.example backend/.env
+  echo "✅ backend/.env を作成しました。必要な値を設定してください。"
+else
+  echo "ℹ️  backend/.env は既に存在します。スキップします。"
+fi
+
+# keys ディレクトリ作成
+mkdir -p backend/keys
+
+# DB マイグレーション
+echo "🗄️  DB マイグレーションを実行します..."
+PYTHONPATH=$(pwd) flask --app backend.app db upgrade
+
+echo ""
+echo "✅ セットアップ完了！"
+echo ""
+echo "次のステップ:"
+echo "  1. backend/.env を編集して以下を設定してください:"
+echo "       CONNECT_AI_PARENT_ACCOUNT_ID=<your-parent-account-id>"
+echo "       CONNECT_AI_PRIVATE_KEY=\"-----BEGIN RSA PRIVATE KEY-----\\n...\\n-----END RSA PRIVATE KEY-----\""
+echo "       SECRET_KEY=<random-string>"
+echo ""
+echo "  2. 開発サーバーを起動:"
+echo "       flask --app backend.app run --port 5001 --debug"
+echo ""
+echo "  3. ブラウザで http://localhost:5001 にアクセス"

--- a/.steering/20260223-devcontainer-setup/requirements.md
+++ b/.steering/20260223-devcontainer-setup/requirements.md
@@ -1,0 +1,71 @@
+# 要求定義: DevContainer 設定の追加
+
+**作業ディレクトリ**: `.steering/20260223-devcontainer-setup/`
+**作成日**: 2026-02-23
+
+---
+
+## 1. 背景・目的
+
+チームメンバーが同一の開発環境でローカル開発できるよう、VS Code Dev Containers 対応の設定ファイルを追加する。
+合わせて、RSA 秘密鍵をファイル配置なしで `.env` の環境変数から渡せるよう対応する。
+
+---
+
+## 2. 変更内容
+
+### 新規作成
+
+#### `.devcontainer/devcontainer.json`
+
+- ベースイメージ: `mcr.microsoft.com/devcontainers/python:3.11`
+- ポート転送: 5001
+- postCreateCommand: `bash .devcontainer/setup.sh`
+- 環境変数: `PYTHONPATH=/workspaces/<プロジェクト名>`
+- VS Code 拡張機能: Python, Pylance, debugpy
+- VS Code 設定: pytest パス等
+
+#### `.devcontainer/setup.sh`
+
+コンテナ初回作成時に自動実行されるセットアップスクリプト。
+
+1. `pip install -r backend/requirements.txt`
+2. `backend/.env` が未作成の場合は `backend/.env.example` からコピー
+3. `backend/keys/` ディレクトリ作成
+4. `flask --app backend.app db upgrade` で DB マイグレーション実行
+
+### 変更
+
+#### `backend/connectai/jwt.py`
+
+RSA 秘密鍵の読み込みに `CONNECT_AI_PRIVATE_KEY` 環境変数を優先対応する。
+
+- `CONNECT_AI_PRIVATE_KEY`（env var）が設定されていればその PEM 文字列を使用
+- 未設定の場合は従来どおり `CONNECT_AI_PRIVATE_KEY_PATH` のファイルパスから読み込み
+- 既存のファイルパス方式との後方互換性を維持
+
+#### `backend/config.py`
+
+- `CONNECT_AI_PRIVATE_KEY: str` 設定項目を追加（デフォルト: 空文字列）
+
+#### `backend/.env.example`
+
+- `CONNECT_AI_PRIVATE_KEY` のコメント付きサンプルを追記
+
+---
+
+## 3. 受け入れ条件
+
+- VS Code で「Reopen in Container」を実行すると `setup.sh` が自動実行される
+- コンテナ起動後、`backend/.env` に必要な環境変数を設定するだけでアプリが起動できる
+- `CONNECT_AI_PRIVATE_KEY` に PEM 文字列を設定すれば `backend/keys/private.key` なしで JWT 生成できる
+- 既存のファイルパス方式（`CONNECT_AI_PRIVATE_KEY_PATH`）は引き続き動作する
+- `pytest backend/tests/ -v` が全 PASS すること
+
+---
+
+## 4. 制約事項
+
+- `.devcontainer/` はプロジェクトルートに配置する
+- `backend/keys/` や `backend/.env` はコンテナに含めない（git 管理外を維持）
+- テストコードは変更しない

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -10,7 +10,12 @@ DATABASE_URL=sqlite:///datahub.db
 CONNECT_AI_BASE_URL=https://cloud.cdata.com/api
 CONNECT_AI_PARENT_ACCOUNT_ID=your-parent-account-id
 
-# RSA秘密鍵ファイルパス
+# RSA秘密鍵（どちらか一方を設定してください）
+# 方法1: 環境変数で PEM 文字列を直接指定（DevContainer / Codespaces 推奨）
+#   改行を \n でエスケープして1行で記載してください
+# CONNECT_AI_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIEow...\n-----END RSA PRIVATE KEY-----"
+#
+# 方法2: ファイルパスを指定（デフォルト）
 CONNECT_AI_PRIVATE_KEY_PATH=backend/keys/private.key
 
 # アプリのベース URL（コールバック URL の組み立てに使用）

--- a/backend/config.py
+++ b/backend/config.py
@@ -21,6 +21,7 @@ class Config:
 
     CONNECT_AI_BASE_URL: str = os.environ.get("CONNECT_AI_BASE_URL", "https://cloud.cdata.com/api")
     CONNECT_AI_PARENT_ACCOUNT_ID: str = os.environ.get("CONNECT_AI_PARENT_ACCOUNT_ID", "")
+    CONNECT_AI_PRIVATE_KEY: str = os.environ.get("CONNECT_AI_PRIVATE_KEY", "")
     CONNECT_AI_PRIVATE_KEY_PATH: str = _resolve_path(
         os.environ.get("CONNECT_AI_PRIVATE_KEY_PATH", "backend/keys/private.key")
     )

--- a/backend/connectai/jwt.py
+++ b/backend/connectai/jwt.py
@@ -16,9 +16,15 @@ def generate_connect_ai_jwt(parent_account_id: str, subject_account_id: str) -> 
     Returns:
         署名済み JWT 文字列
     """
-    private_key_path = current_app.config["CONNECT_AI_PRIVATE_KEY_PATH"]
-    with open(private_key_path, "rb") as f:
-        private_key = serialization.load_pem_private_key(f.read(), password=None)
+    private_key_content = current_app.config.get("CONNECT_AI_PRIVATE_KEY", "")
+    if private_key_content:
+        private_key = serialization.load_pem_private_key(
+            private_key_content.replace("\\n", "\n").encode(), password=None
+        )
+    else:
+        private_key_path = current_app.config["CONNECT_AI_PRIVATE_KEY_PATH"]
+        with open(private_key_path, "rb") as f:
+            private_key = serialization.load_pem_private_key(f.read(), password=None)
 
     now = int(time.time())
     payload = {


### PR DESCRIPTION
- .devcontainer/ を追加し、VS Code DevContainer / GitHub Codespaces でのワンクリック起動を実現
- RSA 秘密鍵を環境変数 CONNECT_AI_PRIVATE_KEY で PEM 文字列として直接指定できる方法を追加 (ファイルパス指定方式と併存。DevContainer / Codespaces 環境で秘密鍵をファイル配置せずに利用可能)
- backend/.env.example に両方の設定方法を記載
- .steering/20260223-devcontainer-setup/requirements.md を追加