### PR TITLE
fix: クエリビルダーで VALIDATION_ERROR が発生するバグを修正 (Close #14)

### DIFF
--- a/backend/schemas/query_schema.py
+++ b/backend/schemas/query_schema.py
@@ -11,7 +11,6 @@ class ConditionSchema(BaseModel):
 
 
 class QueryRequestSchema(BaseModel):
-    connection_id: str
     catalog_name: str
     schema_name: str
     table_name: str

--- a/backend/tests/test_query.py
+++ b/backend/tests/test_query.py
@@ -117,6 +117,27 @@ def test_execute_query_connect_ai_error(client, mock_connect_ai_query):
 
 
 # ---------------------------------------------------------------------------
+# connection_id 不整合バグの修正確認（Issue #14）
+# ---------------------------------------------------------------------------
+
+def test_execute_query_without_connection_id(client, mock_connect_ai_query):
+    """フロントエンドの実際の送信形式（connection_id なし）でクエリが実行できること。
+    Issue #14: QueryRequestSchema の connection_id 必須フィールドが原因で
+    フロントエンドから VALIDATION_ERROR が返っていたバグの回帰テスト。
+    """
+    _register_and_login(client)
+    resp = client.post("/api/v1/query", json={
+        # connection_id を送らない（フロントエンドの実際の挙動と同じ）
+        "catalog_name": "Salesforce1",
+        "schema_name": "dbo",
+        "table_name": "Account",
+        "columns": [],
+        "conditions": [],
+    })
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
 # SQL 組み立て単体テスト
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 概要

Issue #14 の修正。クエリビルダーで「実行」をクリックすると `connection_id: Field required` の VALIDATION_ERROR が返るバグを解消します。

Close #14

## 原因

`QueryRequestSchema` に `connection_id: str`（必須）が残っていたが、実際には：

- **フロントエンド**（`api-client.js` `executeQuery()`）: `connection_id` を送信していない
- **サービス層**（`query_service.py`）: `connection_id` を使用していない（`current_user.connect_ai_account_id` を直接参照）

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `backend/schemas/query_schema.py` | `connection_id: str` フィールドを削除 |
| `backend/tests/test_query.py` | 回帰テスト `test_execute_query_without_connection_id` を追加 |

## テストファースト

1. **RED**: `connection_id` なしのリクエストが `400` を返すことを確認するテストを先に追加
2. **GREEN**: スキーマ修正後、全 136 テストが通過することを確認

```
136 passed in 8.59s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)