### PR TITLE
fix: externalId を user.id から user.email に変更し環境再構築時の重複を防止

### DIFF
--- a/.steering/20260226-fix-external-id/design.md
+++ b/.steering/20260226-fix-external-id/design.md
@@ -1,0 +1,66 @@
+# design.md
+
+## 実装アプローチ
+
+`externalId` の生成箇所は `backend/services/auth_service.py` の1行のみ。
+変更は最小限にとどめ、影響範囲を抑える。
+
+## 変更するファイル
+
+### 1. `backend/services/auth_service.py`（本体修正）
+
+| | コード |
+|---|---|
+| **変更前** | `child_account_id = client.create_account(str(user.id))` |
+| **変更後** | `child_account_id = client.create_account(user.email)` |
+
+`user.email` は DB への INSERT・`commit()` 完了後に確定しており、
+`user.id` と同じタイミングで安全に参照できる。
+
+### 2. `backend/tests/conftest.py`（テスト修正）
+
+`mock_connect_ai` フィクスチャで `create_account` の呼び出し引数を検証している箇所があれば、
+期待値を `user.email` に更新する。
+現状はモックの戻り値のみ設定しており引数の assert はないため、変更不要の可能性が高い。
+
+### 3. `backend/tests/test_auth.py`（テスト修正）
+
+`test_register_saves_child_account_id` は戻り値（`connect_ai_account_id`）のみを検証しており、
+`create_account` への引数は検証していない。変更不要。
+
+引数を明示的に検証するテストケースを1件追加する。
+
+```python
+def test_register_uses_email_as_external_id(client, app, mock_connect_ai):
+    """externalId としてメールアドレスが使用されること"""
+    _register(client, email="user@example.com")
+    mock_connect_ai.assert_called_once_with("user@example.com")
+```
+
+### 4. `docs/glossary.md`（ドキュメント修正）
+
+`externalId` の定義を `users.id` から `users.email` に更新する。
+
+| | 内容 |
+|---|---|
+| **変更前** | `external_id = str(user.id)  # 例: "42"` |
+| **変更後** | `external_id = user.email  # 例: "alice@example.com"` |
+
+## データ構造の変更
+
+なし。`users` テーブルのスキーマ変更は不要。
+
+## 影響範囲の分析
+
+| ファイル | 変更種別 | 影響度 |
+|---|---|---|
+| `backend/services/auth_service.py` | 修正（1行） | 小 |
+| `backend/tests/test_auth.py` | テスト追加（1件） | 小 |
+| `docs/glossary.md` | ドキュメント修正 | 小 |
+| `backend/connectai/client.py` | 変更なし | なし |
+| `backend/tests/conftest.py` | 変更なし | なし |
+
+## 非互換性
+
+- 既存の CData 子アカウント（`externalId = str(user.id)` で作成済み）との後方互換性はない
+- サンプルアプリのため既存データ移行は不要とする

--- a/.steering/20260226-fix-external-id/requirements.md
+++ b/.steering/20260226-fix-external-id/requirements.md
@@ -1,0 +1,37 @@
+# requirements.md
+
+## 関連 Issue
+
+[#16 bug: externalId に user.id を使用しているため環境再構築時に重複が発生する](https://github.com/sugimomoto/ConnectAIOEMSample/issues/16)
+
+## 変更・追加する機能の説明
+
+CData Connect AI に子アカウントを作成する際に使用する `externalId` の値を、
+SQLite の自動採番 `user.id`（整数）から `user.email`（メールアドレス）に変更する。
+
+## 背景・問題
+
+現在の実装では `externalId = str(user.id)` を使用しているため、
+Docker ボリュームを削除して環境を再構築すると `user.id` が 1 からリセットされる。
+その結果、新しく登録したユーザーが過去に削除された別ユーザーと同じ `externalId` を持ち、
+CData 側の子アカウントが意図せず再利用・衝突するバグが発生する。
+
+## ユーザーストーリー
+
+- SaaS 管理者として、環境を再構築した後に新規ユーザーが登録しても、
+  既存の CData 子アカウントと衝突しないことを期待する。
+
+## 受け入れ条件
+
+- `externalId` として `user.email` が CData Connect AI API に送信されること
+- メールアドレスの重複はアプリ側の DB `UNIQUE` 制約によりすでに防止されているため、
+  `externalId` の衝突が起こらないこと
+- 既存のテストがすべてパスすること
+- `docs/glossary.md` の `externalId` の定義が実装と一致していること
+
+## 制約事項
+
+- このアプリではユーザーがメールアドレスを変更する機能を持たないため、
+  `externalId` の変更リスクはない
+- 既存の CData 子アカウント（`externalId = str(user.id)` で作成済みのもの）は
+  本修正の対象外とする（サンプルアプリのため既存データ移行は不要）

--- a/.steering/20260226-fix-external-id/tasklist.md
+++ b/.steering/20260226-fix-external-id/tasklist.md
@@ -1,0 +1,25 @@
+# tasklist.md
+
+## タスク一覧
+
+### 1. 本体修正
+- [ ] `backend/services/auth_service.py` の `create_account(str(user.id))` を `create_account(user.email)` に変更
+
+### 2. テスト追加
+- [ ] `backend/tests/test_auth.py` に `test_register_uses_email_as_external_id` を追加
+
+### 3. ドキュメント更新
+- [ ] `docs/glossary.md` の `externalId` の定義を `user.email` に更新
+
+### 4. 品質チェック
+- [ ] `pytest backend/tests/` を実行してすべてのテストがパスすること
+
+### 5. コミット & PR
+- [ ] 変更をコミット
+- [ ] `fix/external-id-use-email` ブランチを push
+- [ ] Issue #16 を close する PR を作成
+
+## 完了条件
+
+- `pytest` が全テスト GREEN
+- PR がレビュー可能な状態になっている

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -31,7 +31,7 @@ class AuthService:
         error_msg = None
         try:
             client = ConnectAIClient(child_account_id=None)
-            child_account_id = client.create_account(str(user.id))
+            child_account_id = client.create_account(user.email)
             user.connect_ai_account_id = child_account_id
             db.session.commit()
         except ConnectAIError as e:

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -57,6 +57,12 @@ def test_register_saves_child_account_id(client, app):
         assert user.connect_ai_account_id == "mock-child-account-id-001"
 
 
+def test_register_uses_email_as_external_id(client, mock_connect_ai):
+    """externalId としてメールアドレスが Connect AI API に渡されること"""
+    _register(client, email="user@example.com")
+    mock_connect_ai.assert_called_once_with("user@example.com")
+
+
 def test_register_password_is_hashed(client, app):
     """パスワードが平文でなくbcryptハッシュとしてDBに保存されること"""
     _register(client, password="mysecretpass")

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -92,7 +92,7 @@ CDataとの契約により **OEMパートナー（本プロジェクト）** に
 Connect AIにおけるテナント分離の単位となる。
 
 - ユーザー登録時に **Account API** (`POST /poweredby/account/create`) を呼び出して作成される
-- 作成時に `externalId`（本アプリの `users.id` を文字列化した値）を指定する
+- 作成時に `externalId`（本アプリの `users.email`）を指定する
 - Connect AIから返却される `ChildAccountId` を `users.connect_ai_account_id` カラムに保存する
 - `ChildAccountId` は JWT の `sub`（subject）クレームに設定する
 
@@ -101,10 +101,10 @@ Connect AIにおけるテナント分離の単位となる。
 ### externalId（外部ID）
 
 子アカウント作成時にOEMパートナーが指定する識別子。Connect AI側でユーザーを特定するための参照キー。
-本プロジェクトでは `users.id`（整数）を文字列変換して使用する。
+本プロジェクトでは `users.email`（メールアドレス）を使用する。環境再構築時も値が変わらず、DB の `UNIQUE` 制約により衝突しない。
 
 ```python
-external_id = str(user.id)  # 例: "42"
+external_id = user.email  # 例: "alice@example.com"
 ```
 
 ### ChildAccountId（子アカウントID）


### PR DESCRIPTION
## Summary

- `externalId` に `str(user.id)` を使用していたため、Docker ボリューム削除等で DB を再構築すると `user.id` が 1 からリセットされ、異なるユーザーが同じ `externalId` を持つ可能性があった
- `user.email` は DB の `UNIQUE` 制約で一意性が保証され、環境再構築の影響を受けないため `externalId` として採用するよう変更

## Changes

- `backend/services/auth_service.py`: `create_account(str(user.id))` → `create_account(user.email)`
- `backend/tests/test_auth.py`: `externalId` に email が渡されることを検証するテスト `test_register_uses_email_as_external_id` を追加
- `docs/glossary.md`: `externalId` の定義を `user.email` に更新
- `.steering/20260226-fix-external-id/`: 作業ドキュメントを追加

## Test plan

- [x] `pytest backend/tests/` — 137 passed

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)